### PR TITLE
Add popover menu

### DIFF
--- a/PopoverMenu.tsx
+++ b/PopoverMenu.tsx
@@ -1,0 +1,116 @@
+import React, { useRef, useState, useEffect } from 'react';
+// This is an SVG of three dots - it has gone through preprocessing and will render when used as <EllipsesMenuIcon />
+import EllipsesMenuIcon from './EllipsesMenuIcon.svg';
+
+interface PopoverMenuItem {
+  name: string;
+  onSelect: () => void;
+  key: number;
+  href?: string;
+}
+
+interface PopoverMenuProps {
+  menuItems: PopoverMenuItem[];
+  useButtonForSecondItem: boolean;
+}
+
+function FocusableLinks({
+  menuItems,
+  closeMenu,
+  useButtonForSecondItem = false,
+}: PopoverMenuProps & { closeMenu: () => void }) {
+  const linkRefs = useRef<(HTMLAnchorElement | HTMLButtonElement | null)[]>([]);
+
+  useEffect(() => {
+    linkRefs.current[0]?.focus();
+  }, [linkRefs]);
+
+  /**
+   * Handles the blur event for the menu item
+   * @param index - index of the menu item
+   */
+  const handleBlur = (index: number) => {
+    if (index === menuItems.length - 1) {
+      closeMenu();
+    }
+  };
+
+  return (
+    <ul>
+      {menuItems.map((item, index) => (
+        <React.Fragment key={item.key}>
+          <li>
+            {useButtonForSecondItem && index === 1 ? (
+              <button
+                type="button"
+                ref={el => {
+                  linkRefs.current[index] = el;
+                }}
+                onClick={item.onSelect}
+                onBlur={() => handleBlur(index)}
+              >
+                {item.name}
+              </button>
+            ) : (
+              <a
+                href={item.href}
+                ref={el => {
+                  linkRefs.current[index] = el;
+                }}
+                onClick={item.onSelect}
+                target="_blank"
+                onBlur={() => handleBlur(index)}
+                onKeyDown={(e: React.KeyboardEvent<HTMLAnchorElement>) => {
+                  if (e.key === ' ') {
+                    item.onSelect();
+                  }
+                }}
+                rel="noreferrer"
+              >
+                {item.name}
+              </a>
+            )}
+          </li>
+          {index < menuItems.length - 1 && (
+            <div className="horizontal-divider" />
+          )}
+        </React.Fragment>
+      ))}
+    </ul>
+  );
+}
+
+function PopoverMenu({ menuItems, useButtonForSecondItem }: PopoverMenuProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
+  const popoverRef = useRef<HTMLDivElement | null>(null);
+
+  const toggleMenu = () => setIsOpen(!isOpen);
+  const closeMenu = () => setIsOpen(false);
+
+  return (
+    <div>
+      <button
+        type="button"
+        ref={buttonRef}
+        aria-expanded={isOpen}
+        aria-controls="popover-menu"
+        onClick={toggleMenu}
+      >
+        <EllipsesMenuIcon />
+      </button>
+
+      {isOpen && (
+        <div ref={popoverRef} id="popover-menu">
+          <FocusableLinks
+            menuItems={menuItems}
+            closeMenu={closeMenu}
+            useButtonForSecondItem={useButtonForSecondItem}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default PopoverMenu;

--- a/StopDetailHeading.tsx
+++ b/StopDetailHeading.tsx
@@ -3,16 +3,17 @@ import PopoverMenu from './PopoverMenu';
 
 interface StopDetailHeadingProps {
   name: string;
+  stopId: number;
   onStopAmenitiesClick: () => void;
 }  
 
-function StopDetailHeading({ name, onStopAmenitiesClick }: StopDetailHeadingProps) {
+function StopDetailHeading({ name, stopId, onStopAmenitiesClick }: StopDetailHeadingProps) {
   
   const menuItems = [
     {
       name: 'Stop Schedule',
-      onSelect: navigateToSchedule,
-      href: stopScheduleLink,
+      onSelect:  window.open('https://trimet.org/ride/stop_schedule.html?_LOCALE_=en&stop_id=${stopId}', '_blank'),
+      href: 'https://trimet.org/ride/stop_schedule.html?_LOCALE_=en&stop_id=${stopId}',
       key: 0
     },
     {

--- a/StopDetailHeading.tsx
+++ b/StopDetailHeading.tsx
@@ -1,9 +1,32 @@
 import React from 'react';
+import PopoverMenu from './PopoverMenu';
 
 interface StopDetailHeadingProps {
   name: string;
+  onStopAmenitiesClick: () => void;
 }  
 
-function StopDetailHeading({ name }: StopDetailHeadingProps) {
-  return <h2>{name}</h2>
+function StopDetailHeading({ name, onStopAmenitiesClick }: StopDetailHeadingProps) {
+  
+  const menuItems = [
+    {
+      name: 'Stop Schedule',
+      onSelect: navigateToSchedule,
+      href: stopScheduleLink,
+      key: 0
+    },
+    {
+      name: 'Stop Amenities',
+      // this opens a modal containing the stop amenities
+      onSelect: onStopAmenitiesClick,
+      key: 1
+    }
+  ];
+  
+  return (
+    <h2>
+      {name}
+      <PopoverMenu menuItems={menuItems} useButtonForSecondItem />
+    </h2>
+  )
 }


### PR DESCRIPTION
This is a sample popover menu component for practice code review. We'd like you to perform a code review on this pull request, [leaving comments inline](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request) on the changed files. You're also welcome to provide overall comments on the pull request if you like. We'll talk through the completed code review together during your interview. 

Please spend no more than an hour performing this code review. You are welcome to use any testing tools and reference documentation you would ordinarily use in the course of code review, but we ask that you do **not** use AI to perform the code review for you. 

You can view a rendered version of this component by visiting [this test page](https://labs.trimet.org/home-plusqa-1/stop/7640/). The button that opens the component is visually three dots and appears immediately following the stop name, SW 5th & Taylor (highlighted in the red box below). 
![Screenshot 2024-12-18 154130](https://github.com/user-attachments/assets/6d0a5a2b-dc83-479e-9521-4e52f85c54df)

Clicking the three dots button opens a popover menu, which is a list of actionable items that can be a mix of buttons and links. 
![Screenshot 2024-12-18 154236](https://github.com/user-attachments/assets/cf46beda-7539-4241-96c0-a90738852849)

The rendered component includes styling which is not present in this pull request for simplicity's sake; please focus on the code included in this pull request. Also, we know there are lots of accessibility issues on the page as a whole, but we ask that you focus your time and energy on just the component in this pull request.

While we've included one sample implementation here, the goal is for this component to be reusable in different areas around the site. So in the future you can imagine that we'd want to use `PopoverMenu` to provide additional information on different pages, with different sets of `menuItems` being passed in. Perhaps we'd have a case where we pass five links in as `menuItems`, or a set of three different action buttons. 

 As you're doing the code review, we'd like you to think about the following: 
1) Is this code easily readable, understandable, and maintainable? 
2) Will we be able to use the `PopoverMenu` in different places around the site?
3) Are there any accessibility issues with this component?

We also welcome questions on any code that may be confusing or unclear. Code review can be a great opportunity for curiosity and learning, especially as this is code from an unfamiliar code base. 

Please reach out if you have any questions or access issues commenting on this pull request or viewing the rendered component. 
